### PR TITLE
Updated write API to support pandas df ingest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 config.json
 __pychache__
 influxdb_client_3/__pycache__/
+.venv

--- a/influxdb_client_3/__init__.py
+++ b/influxdb_client_3/__init__.py
@@ -4,31 +4,36 @@ import pyarrow.flight as flight
 from flightsql import FlightSQLClient
 from influxdb_client import InfluxDBClient as _InfluxDBClient
 from influxdb_client.client.write_api import WriteApi as _WriteApi
+from influxdb_client.client.write_api import SYNCHRONOUS
 from influxdb_client import Point
 
 class InfluxDBClient3:
-    def __init__(self, url=None, token=None, host=None, org=None, namespace=None):
+    def __init__(self, url=None, token=None, host=None, org=None, namespace=None, **kwargs):
         self._org = org
         self._namespace = namespace
      
-        self._client = _InfluxDBClient(url=f"https://{host}", token=token)
-        self._write_api = _WriteApi(self._client)
+        self._client = _InfluxDBClient(url=f"https://{host}", token=token, org=self._org, **kwargs )
+        self._write_api = _WriteApi(self._client, write_options=SYNCHRONOUS )
         self._flight_sql_client = FlightSQLClient(host=host,
                                                   token=token,
                                                   metadata={'bucket-name':namespace})
 
-    def write(self, record=None):
+    def write(self, record=None, **kwargs):
         """
         Write data to InfluxDB.
 
         :type namespace: str
         :param record: The data point(s) to write.
         :type record: Point or list of Point objects
+        :param kwargs: Additional arguments to pass to the write API.
         """
         try:
-            self._write_api.write(bucket=self._namespace, record=record, org=self._org)
+            self._write_api.write(bucket=self._namespace, record=record, **kwargs)
         except Exception as e:
             print(e)
+    
+
+
 
     def query(self, sql_query):
         """


### PR DESCRIPTION
Added `**kwargs` to Client creation and write options. This allows users to interact with other options of the underlining client. 

Possible use case (writing pandas df to influxdb):
```python
import influxdb_client_3 as InfluxDBClient3
import pandas as pd
import numpy as np

client = InfluxDBClient3.InfluxDBClient3(token="spqIiWojlcbAQC-FotEltyPqKhlhppuo36DYc5RIXxZl3EM3nRvSDQ3Lc75tkjBlml__oG3bI199gG3IdVKYlw==",
                         host="eu-central-1-1.aws.cloud2.influxdata.com",
                         org="6a841c0c08328fb1",
                         namespace="test")



# Create a dataframe
df = pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})


# Create a range of datetime values
dates = pd.date_range(start='2023-03-01', end='2023-03-29', freq='5min')

# Create a DataFrame with random data and datetime index
df = pd.DataFrame(np.random.randn(len(dates), 3), index=dates, columns=['Column 1', 'Column 2', 'Column 3'])
df['tagkey'] = 'Hello World'

print(df)

# Write the DataFrame to InfluxDB
client.write(df, data_frame_measurement_name='table', data_frame_tag_columns=['tagkey']) 
```


 